### PR TITLE
Fix wrong use of reference returned by setTimeout

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,15 +1,12 @@
-import React, { useEffect, useState } from "react";
-import {
-  NotificationContainer,
-  NotificationManager
-} from "react-notifications";
-import "react-notifications/lib/notifications.css";
-import useIsOnlineNotification from "./hooks/isOnlineNotification";
-import OnlineStatusMock from "./OnlineStatusMock";
-import "./App.css";
+import React, {useEffect, useState} from 'react'
+import {NotificationContainer, NotificationManager} from 'react-notifications'
+import 'react-notifications/lib/notifications.css'
+import useIsOnlineNotification from './hooks/isOnlineNotification'
+import OnlineStatusMock from './OnlineStatusMock'
+import './App.css'
 
 const withOnlineStatus = (WrappedComponent) => {
-  const WithOnlineStatus = (props) => {
+  return (props) => {
     const [
       isOnlineNotification,
       setIsOnlineNotification
@@ -25,12 +22,10 @@ const withOnlineStatus = (WrappedComponent) => {
         <OnlineStatusMock
           onIsOnlineChange={(isOnline) => setIsOnline(isOnline)}
         />
-        <WrappedComponent {...props} isOnline={isOnlineNotification} />
+        <WrappedComponent {...props} isOnline={isOnlineNotification}/>
       </>
     );
   };
-
-  return WithOnlineStatus;
 };
 
 const App = (props) => {

--- a/src/hooks/isOnlineNotification/index.js
+++ b/src/hooks/isOnlineNotification/index.js
@@ -1,27 +1,27 @@
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
-let reconnectionTimeOut = null;
 const THROTTLE_TIME = 2000;
 const DISCONNECTED = false;
 
 const useIsOnlineNotification = () => {
+  const reconnectionTimeOut = useRef(null)
   const [isOnlineApp, setIsOnlineApp] = useState(false);
   const [isOnlineNotification, setIsOnlineNotification] = useState(false);
 
   useEffect(() => {
     if (isOnlineApp === DISCONNECTED) {
-      reconnectionTimeOut = setTimeout(() => {
+      reconnectionTimeOut.current = setTimeout(() => {
         setIsOnlineNotification(false);
       }, THROTTLE_TIME);
     } else {
-      clearTimeout(reconnectionTimeOut)
+      clearTimeout(reconnectionTimeOut.current)
       setIsOnlineNotification(true);
     }
 
     return () => {
-      clearTimeout(reconnectionTimeOut)
-    }    
+      clearTimeout(reconnectionTimeOut.current)
+    }
   }, [isOnlineApp]);
 
   return [


### PR DESCRIPTION
The approach, even that it worked, didn't follow the right React component lifecycle.

To fix it just changed the let variable to a **useRef** where you can mutate the current property of the object.

Small refactor done for fixing a redundancy in naming.